### PR TITLE
V1 release fixes and styling 

### DIFF
--- a/drokar-js/src/App.css
+++ b/drokar-js/src/App.css
@@ -13,6 +13,15 @@
   justify-content: center;
 }
 
+.infoPanel {  
+  margin: 0 auto;
+}
+
+.smallMargin {
+  margin: 5px;
+}
+
+
 .flexContainerNoCenter {
   display: flex;
   align-items: center;
@@ -23,7 +32,8 @@
   display: flex;
   flex-direction: row;
   grid-template-columns: 50%, 50%;
-  border: 5px solid black;
+  border: 2px solid darkslategray;
+  border-radius: 2px;
   height:400px;
 }
 
@@ -31,6 +41,7 @@
   height: 100%;
   width: 50%;
   border: 1px solid grey;
+  z-index: 10;
 }
 
 
@@ -41,6 +52,7 @@
 .Events {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  border: 2px solid darkslategray;
+  padding: 8px;
 }
-
-

--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -93,6 +93,7 @@ function App() {
   const [attackProg, setAttackProg] = useState(0)
   const [enemyAttackProg, setEnemyAttackProg] = useState(0)
   const [activeCombat, setActiveCombat] = useState(false)
+  const [sellQuantity, setSellQuantity] = useState(1)
 
   const [activeAttack, setActiveAttack] = useState([])
   const [activeEnemyAttack, setActiveEnemyAttack] = useState([])
@@ -232,7 +233,7 @@ function App() {
   return (
     <Box sx={{display: 'flex'}}>
       <CssBaseline />
-      <PlayerDataContext.Provider value={{playerData, setPlayerData, activeTask, setActiveTask, playerLevels, activeMonster, setActiveMonster}}>
+      <PlayerDataContext.Provider value={{playerData, setPlayerData, activeTask, setActiveTask, playerLevels, activeMonster, setActiveMonster, activeCombat, setActiveCombat, sellQuantity, setSellQuantity}}>
       <SideBar playerLevels={playerLevels} setActiveSkill={setActiveSkill}/>
         <Box
             component="main"

--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -230,12 +230,10 @@ function App() {
   console.log(`Checking activeMonster`)
 
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Box sx={{display: 'flex'}}>
       <CssBaseline />
       <PlayerDataContext.Provider value={{playerData, setPlayerData, activeTask, setActiveTask, playerLevels, activeMonster, setActiveMonster}}>
-        <Drawer variant="permanent" open={true} sx={{ position: 'relative' }}>
-          <SideBar playerLevels={playerLevels} setActiveSkill={setActiveSkill}/>
-        </Drawer>
+      <SideBar playerLevels={playerLevels} setActiveSkill={setActiveSkill}/>
         <Box
             component="main"
             sx={{

--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -204,6 +204,12 @@ function App() {
     console.log('entering launchCombat function')
     playerData = rollAttackType(playerData)
     activeMonster = rollAttackType(activeMonster)
+    
+    setAttackProg(0)
+    setEnemyAttackProg(0)
+    refAttackProg.current = 0
+    refEnemyAttackProg.current = 0
+
     let prog = 100 / (playerData.combatStats.attackSpeed / tickRate)
     let enemyProg = 100 / (activeMonster.combatStats.attackSpeed / tickRate)
     

--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -263,7 +263,9 @@ function App() {
             }
             </div>
           </Box>
-          <Button onClick={(e)=>{launchCombat(activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster,  setAttackProg, setEnemyAttackProg)}}>Launch Combat</Button>
+          <div className='flexContainer smallMargin'>
+            <Button variant="contained" color="error" onClick={(e)=>{launchCombat(activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster,  setAttackProg, setEnemyAttackProg)}}>Fight!</Button>
+          </div>
         </Box>
     </PlayerDataContext.Provider>
     </Box>

--- a/drokar-js/src/components/Combat.css
+++ b/drokar-js/src/components/Combat.css
@@ -15,6 +15,18 @@
     width: 100%;
 }
 
+.fightButtons {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    justify-content: space-around;
+    width: 40%;
+}
+
+
+.combatStatList > p {
+    margin: 0 auto;
+}
 .monsterTask {
     display: flex;
     flex-direction: row;

--- a/drokar-js/src/components/CombatFrame.js
+++ b/drokar-js/src/components/CombatFrame.js
@@ -111,7 +111,7 @@ function CombatFrame({combatData, name, attackProg, activeAttack}) {
             Damage: {combatData.meleeDamage} <br></br>
             Attack speed : {combatData.attackSpeed/1000}s<br></br>
             <div className= "divider"></div>
-            Melee Defense: {combatData.armor}<br></br>
+            Melee Defense: {combatData.meleeArmor}<br></br>
             Ranged Defense: {combatData.rangedArmor}<br></br>
             Magic Defense: {combatData.magicArmor}<br></br>
             <div className= "divider"></div>

--- a/drokar-js/src/components/CombatTasks.js
+++ b/drokar-js/src/components/CombatTasks.js
@@ -18,9 +18,18 @@ const setMonsterData = (selectedMonster, setActiveMonster) => {
     setActiveMonster(activeMonster)
 }
 
+const fleeCombat = (activeCombat, setActiveCombat, setActiveMonster) => {
+    console.log("Fleeing combat")
+    if (activeCombat) {
+        setActiveCombat(false)
+        clearInterval(activeCombat)
+    }
+    setActiveMonster({})
+}
+
 function CombatTasks() { 
     const [selectedMonster, setSelectedMonster] = useState('')
-    const {activeMonster, setActiveMonster} = useContext(PlayerDataContext)
+    const {activeMonster, setActiveMonster, activeCombat, setActiveCombat} = useContext(PlayerDataContext)
     return (
         <div className="combatTasks">
             {Object.keys(MonsterData).map(function(monsterName, i) {
@@ -30,8 +39,15 @@ function CombatTasks() {
                     </div>
             }         
             )}
-            {selectedMonster ? <div>Selected Monster: {selectedMonster}</div> : null}
-            <Button variant="contained" color="error" onClick={() => setMonsterData(selectedMonster, setActiveMonster)}> Fight! </Button>
+            {selectedMonster 
+                ? <div>
+                    Selected Monster: {selectedMonster}
+                    <div className="fightButtons">
+                    <Button variant="contained" className="paddedBtn" color="error" onClick={() => setMonsterData(selectedMonster, setActiveMonster)}> Target </Button>
+                    <Button variant="contained" color="warning" onClick={() => fleeCombat(activeCombat, setActiveCombat, setActiveMonster)}> Flee in Terror! </Button>
+                    </div>
+                </div>
+             : null}
         </div>
     )
     }

--- a/drokar-js/src/components/Equipment.css
+++ b/drokar-js/src/components/Equipment.css
@@ -53,6 +53,17 @@ background-color: #5D3413;
 background-size: 30px 30px;
 padding: 10px;
 width:100%;
+z-index: 10;
+}
+
+.equipmentTip {
+    color: white;
+    font-size: 14px;
+    font-weight: bold;
+    font-family: 'Calibri';
+    position: absolute;
+    bottom: 0;
+    right: 6%;
 }
 
 .grid-container > div {

--- a/drokar-js/src/components/Equipment.js
+++ b/drokar-js/src/components/Equipment.js
@@ -53,7 +53,7 @@ function Equipment({playerData, setPlayerData}) {
         {EquipSlot("offHand", playerData, setPlayerData)}
         <div className="blank3 blank"></div>
         {EquipSlot("leg", playerData, setPlayerData)}
-        <div className="blank4 blank"></div>
+        <div className="blank4 blank"><a className='equipmentTip'>Double click slot <br/> to  unequip item </a> </div>
         {EquipSlot("feet", playerData, setPlayerData)}
       </div>
     );

--- a/drokar-js/src/components/Events.js
+++ b/drokar-js/src/components/Events.js
@@ -8,18 +8,19 @@ function Events(props) {
     let skill = activeTask.skill
     return (
       <div className="Events">
-        Events
-        <div>{activeTask.name}</div>
-
         {JSON.stringify(activeTask) === "{}"
-          ? null
-          : <ProgressLine key={playerData.skills[skill].toString()+activeTask.name} visualParts={[ 
+          ? <div className="testo"><p className="infoPanel">Click on Prospecting or Metallurgy to start a task or start fighting from the Combat window.
+          <br/> Mine ores with Prospecting, smelt them with Metallurgy, smith bars into weapons and armor and fight the goblins! 
+          <br/> You will unlock more tasks as you level up your skills.  </p></div>
+          :  <div>
+              {activeTask.name} - {(activeTask.duration/1000).toFixed(1)} seconds
+              <ProgressLine key={playerData.skills[skill].toString()+activeTask.name} visualParts={[ 
                 {
                   percentage:"100%",
                   color:"red",
                 }
                 ]} speed={activeTask.duration/1000}/>
-              }
+              </div>}
       </div>
     );
   }

--- a/drokar-js/src/components/Inventory.js
+++ b/drokar-js/src/components/Inventory.js
@@ -8,9 +8,10 @@ import { PlayerDataContext } from '../helpers/Contexts';
 import { useContext, useState} from 'react';
 import { Button } from '@mui/material';
 
-const toggleActiveItem = (itemName, activeItem, setActiveItem) => {
+const toggleActiveItem = (itemName, activeItem, setActiveItem, setSellQuantity) => {
     if (activeItem != itemName) {
       setActiveItem(itemName)
+      setSellQuantity(1)
     }
     else {setActiveItem('')}
   }
@@ -20,7 +21,7 @@ const toggleEquipment = (showEquipment, setShowEquipment) => {
     }
 
 function Inventory() {
-    const {playerData, setPlayerData} = useContext(PlayerDataContext)
+    const {playerData, setPlayerData, setSellQuantity} = useContext(PlayerDataContext)
     const [activeItem, setActiveItem] = useState('')
     const [showEquipment, setShowEquipment] = useState(false)
     const [activeMonster, setActiveMonster] = useState({})
@@ -33,7 +34,7 @@ function Inventory() {
               <img src={gold}></img>{playerData.gold} gold
           </div>
           <div className="inventoryActionButtons">
-              <Button sx={{fontSize: "10px", fontWeight: "bold"}} variant="contained" className="sellButton" onClick={(e) => setShowEquipment(!showEquipment)}> Toggle Equipment </Button>
+              <Button sx={{fontSize: "10px", fontWeight: "bold"}} variant="contained" className="sellButton" onClick={(e) => setShowEquipment(!showEquipment)}> Show Equipped Items </Button>
           </div>
         </div>
         <div className="itemZone">
@@ -49,7 +50,7 @@ function Inventory() {
             <div className="inventoryGrid">
                 {Object.keys(inventory_items).map(function(itemName, i) {
                     return inventory_items[itemName].quantity > 0 
-                    ?  <div onClick={() => toggleActiveItem(itemName, activeItem, setActiveItem)}>
+                    ?  <div onClick={() => toggleActiveItem(itemName, activeItem, setActiveItem, setSellQuantity)}>
                         <InventoryItem  
                         itemName={itemName} 
                         quantity={inventory_items[itemName].quantity} />

--- a/drokar-js/src/components/ItemInfoPanel.css
+++ b/drokar-js/src/components/ItemInfoPanel.css
@@ -1,6 +1,6 @@
 .descriptionName {
-    width:50%;
-    max-width:50%;
+    width:60%;
+    max-width:60%;
     height:50%;
   }
 
@@ -9,15 +9,29 @@
 .itemTitle {
     font-weight: bold;
     font-size: 12px;
+    text-align: center;
 }
 
 .itemDescription {
     font-style: italic;
     font-size: 10px;
+    text-align: center;
+    height: 55px;
+}
+
+.marginAuto {
+    margin: 5px auto;
+}
+
+.combatText {
+    font-size: 12px;
+    text-align: center;
+
 }
   
 .itemInfoPanel {
-    width:35%;
+    width:50%;
+    max-width: 40%;
     border: 3px solid slategray;
     border-radius: 4px;
     background-color: rgba(200, 164, 96, 0.9);
@@ -27,14 +41,20 @@
 }
 
 .descriptionImageContainer .inventoryItem {
-    transform: scale(0.8);
+    transform: scale(0.87);
     max-width: 100%;
     max-height: 100%;
+    margin: 0;
 }
 
+
 .descriptionImageContainer {
-    width:50%;
-    max-width:50%;
+    width:40%;
+    padding-top: 5px;
+}
+
+.sellContainer {
+    text-align: center;
 }
 
 .imageDescription {

--- a/drokar-js/src/components/ItemInfoPanel.js
+++ b/drokar-js/src/components/ItemInfoPanel.js
@@ -99,18 +99,20 @@ function ItemInfoPanel({itemName, quantity, playerData, setPlayerData, setActive
             <p className="itemDescription">{ItemData[itemName].description}</p>
           </div>
           </div>
-        <div>Sells for {ItemData[itemName].sellValue}gp each
+        <div className="sellContainer">Sells for {ItemData[itemName].sellValue}gp each
           <Slider
             sx = {{width:'80%',}}
             size="small"
             defaultValue={1}
+            value={sellQuantity}
             aria-label="Small"
             min = {1}
-            max = {quantity}
+            max = {playerData.inventory[itemName].quantity}
             valueLabelDisplay="auto"
             onChange={(e) => measureSlider(e, setSellQuantity)} 
             />
-          <div style={{"display":"flex"}}>
+          <p className='marginAuto'>Sell {sellQuantity} for {ItemData[itemName].sellValue * sellQuantity} gp?</p>
+          <div style={{"display":"flex", 'gap': '6px'}}>
           <Button variant="contained" endIcon={<TollIcon/>} onClick={()=> sellItem(itemName, sellQuantity, playerData, setPlayerData, setActiveItem)}>
           Sell
           </Button>

--- a/drokar-js/src/components/ItemInfoPanel.js
+++ b/drokar-js/src/components/ItemInfoPanel.js
@@ -2,7 +2,8 @@ import { ItemData } from "../helpers/ItemData";
 import InventoryItem from "./InventoryItem";
 import { Slider, Button } from "@mui/material";
 import TollIcon from '@mui/icons-material/Toll';
-import { useState } from "react";
+import { PlayerDataContext } from "../helpers/Contexts";
+import { useContext } from "react";
 import './ItemInfoPanel.css'
 
 const measureSlider = (event, setSellQuantity) => {
@@ -85,7 +86,7 @@ const equipItem = (itemName, playerData, setPlayerData, setActiveItem) => {
 // Item information panel which shows the item, description, sell value, and slider to sell
 // TODO = Acquired and used by section, it's own tab?
 function ItemInfoPanel({itemName, quantity, playerData, setPlayerData, setActiveItem}) {
-    const [sellQuantity, setSellQuantity] = useState(1)
+  const {sellQuantity, setSellQuantity} = useContext(PlayerDataContext)
     return (
       <div className="itemInfoPanel">
         <div className="imageDescription">

--- a/drokar-js/src/components/ItemInfoPanel.js
+++ b/drokar-js/src/components/ItemInfoPanel.js
@@ -2,6 +2,7 @@ import { ItemData } from "../helpers/ItemData";
 import InventoryItem from "./InventoryItem";
 import { Slider, Button } from "@mui/material";
 import TollIcon from '@mui/icons-material/Toll';
+import { Security } from "@mui/icons-material";
 import { PlayerDataContext } from "../helpers/Contexts";
 import { useContext } from "react";
 import './ItemInfoPanel.css'
@@ -114,7 +115,7 @@ function ItemInfoPanel({itemName, quantity, playerData, setPlayerData, setActive
           Sell
           </Button>
           {"equip" in ItemData[itemName] ?
-          <Button variant="contained" endIcon={<TollIcon/>} sx={{backgroundColor:'orange'}} onClick={()=> equipItem(itemName, playerData, setPlayerData, setActiveItem)}> Equip </Button>
+          <Button variant="contained" endIcon={<Security/>} sx={{backgroundColor:'orange'}} onClick={()=> equipItem(itemName, playerData, setPlayerData, setActiveItem)}> Equip </Button>
           : null
           }
           </div>

--- a/drokar-js/src/components/ItemInfoPanel.js
+++ b/drokar-js/src/components/ItemInfoPanel.js
@@ -10,6 +10,18 @@ const measureSlider = (event, setSellQuantity) => {
   setSellQuantity(event.target.value)
 }
 
+const statNames = {
+  'meleeDamage': 'Melee Damage', 
+  'armor': 'Melee Armor', 
+  'rangedArmor': 'Ballistic Armor',
+  'magicArmor': 'Magic Armor',
+  'attackSpeed': 'Attack Speed', 
+  'maxHp': 'Max HP', 
+  'maxMana': 'Max Mana', 
+  'maxFury': 'Max Fury',
+  'blockChance': 'Block Chance',
+  'blockAmount':'Block Amount'}
+
 const sellItem = (itemName, sellQuantity, playerData, setPlayerData, setActiveItem) => {
   console.log(JSON.stringify(playerData))
   let newPlayerData = {...playerData}
@@ -105,8 +117,20 @@ function ItemInfoPanel({itemName, quantity, playerData, setPlayerData, setActive
           : null
           }
           </div>
-          <br></br>
-          Sell {sellQuantity} for {ItemData[itemName].sellValue * sellQuantity} gp?
+          {"equip" in ItemData[itemName] 
+            ? <div className='combatStatList'>
+                <p><b>Bonuses when equipped:</b></p>
+                  {Object.entries(ItemData[itemName].combatStats).map(([stat, value]) => {
+                    if (stat == "attackSpeed") {
+                      value = (value / 1000).toFixed(2).toString() + " /s"
+                    }
+                    else if (value >0) 
+                      {value = `+${value.toString()}`} 
+                    return <p className="combatText">{statNames[stat]}: {value}</p>
+                  })}
+              </div>
+            : null
+          }
         </div>
       </div>
     );

--- a/drokar-js/src/components/SideBar.js
+++ b/drokar-js/src/components/SideBar.js
@@ -31,7 +31,7 @@ function SideBar({playerLevels, setActiveSkill}) {
               </List>
               <Divider />
               <List>
-                {['Combat', 'Bank (TBD)', 'Job Tree (TBD)'].map((text, index) => (
+                {['Combat'].map((text, index) => (
                   <ListItem key={text} disablePadding>
                      <ListItemButton onClick={() => setActiveSkill(text)}>
                       <ListItemIcon>

--- a/drokar-js/src/helpers/ItemData.js
+++ b/drokar-js/src/helpers/ItemData.js
@@ -12,7 +12,7 @@ export const ItemData = {
     // Prospecting items
     "Copper Ore":{
         sellValue: 5,
-        description: "A red ore, can be refined using Metallurgy",
+        description: "A red ore, can be refined using Metallurgy. It's red, trust me.",
         image: copper,
         acquiredBy: ["Prospecting Level 1", "Combat"],
         usedIn: {'Metallurgy':1}
@@ -20,7 +20,7 @@ export const ItemData = {
     "Tin Ore":
         {
         sellValue: 5,
-        description: "A faint silver ore, can be refined using Metallurgy",
+        description: "A faint silver ore, smelt with Copper Ore using Metallurgy",
         image: tin,
         acquiredBy: ["Prospecting Level 1", "Combat"],
         usedIn: {'Metallurgy':1}


### PR DESCRIPTION
## New Features 
- Some tutorial text to navigate users on what to do
- Equipped bonuses now show when selecting an item in inventory
- Equipment window now overlaps components, can successfully interact and unequip items now
- Added a "Flee in terror!" button for craven fighters

## Fixes in this PR
- Fix bad side menu positioning
- Fixed gold exploit where you could set the sell quantity high, switch to a more expensive item and sell that
- Fixed a bug where an attack would immediately land when starting combat more than once
-  Adjusted a lot of styling 

