### PR TITLE
Combat fixes

### DIFF
--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -201,20 +201,27 @@ function App() {
 
   const launchCombat = (activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster, setAttackProg, setEnemyAttackProg, activeTask, setActiveTask) => {
     // Calculate per tick progression based on attackSpeed and tickRate
+
     // Clear running Prospecting or Metallurgy task if it exists
     clearInterval(activeTask.taskId)
     setActiveTask({})
+
+    // Roll the type of attack to be made
     playerData = rollAttackType(playerData)
     activeMonster = rollAttackType(activeMonster)
     
+    // Reset attack progress
     setAttackProg(0)
     setEnemyAttackProg(0)
     refAttackProg.current = 0
     refEnemyAttackProg.current = 0
 
+    // Calculate attack progression per tick
     let prog = 100 / (playerData.combatStats.attackSpeed / tickRate)
     let enemyProg = 100 / (activeMonster.combatStats.attackSpeed / tickRate)
     
+
+    // If combat is not active, start the combat loop and set states
     if (!activeCombat) {
       const timer = setInterval(() => {
           prog = 100 / (playerData.combatStats.attackSpeed / tickRate)
@@ -236,7 +243,6 @@ function App() {
       setActiveCombat(false)
     }
     }
-  console.log(`Checking activeMonster`)
 
   return (
     <Box sx={{display: 'flex'}}>

--- a/drokar-js/src/App.js
+++ b/drokar-js/src/App.js
@@ -199,9 +199,11 @@ function App() {
 
       }, [attackProg, enemyAttackProg])
 
-  const launchCombat = (activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster, setAttackProg, setEnemyAttackProg) => {
+  const launchCombat = (activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster, setAttackProg, setEnemyAttackProg, activeTask, setActiveTask) => {
     // Calculate per tick progression based on attackSpeed and tickRate
-    console.log('entering launchCombat function')
+    // Clear running Prospecting or Metallurgy task if it exists
+    clearInterval(activeTask.taskId)
+    setActiveTask({})
     playerData = rollAttackType(playerData)
     activeMonster = rollAttackType(activeMonster)
     
@@ -271,7 +273,7 @@ function App() {
             </div>
           </Box>
           <div className='flexContainer smallMargin'>
-            <Button variant="contained" color="error" onClick={(e)=>{launchCombat(activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster,  setAttackProg, setEnemyAttackProg)}}>Fight!</Button>
+            <Button variant="contained" color="error" onClick={(e)=>{launchCombat(activeCombat, setActiveCombat, playerData, setPlayerData, activeMonster, setActiveMonster,  setAttackProg, setEnemyAttackProg, activeTask, setActiveTask)}}>Fight!</Button>
           </div>
         </Box>
     </PlayerDataContext.Provider>

--- a/drokar-js/src/components/CombatTasks.js
+++ b/drokar-js/src/components/CombatTasks.js
@@ -14,7 +14,10 @@ const setMonsterData = (selectedMonster, setActiveMonster) => {
                     maxFury: 100,
                     }
 
-    let activeMonster = {...MonsterData[selectedMonster], combatStats: combatStats}
+    let activeMonster = {...MonsterData[selectedMonster], 
+            combatStats: combatStats,
+            name: selectedMonster
+        }
     setActiveMonster(activeMonster)
 }
 

--- a/drokar-js/src/components/Events.js
+++ b/drokar-js/src/components/Events.js
@@ -9,7 +9,7 @@ function Events(props) {
     return (
       <div className="Events">
         {JSON.stringify(activeTask) === "{}"
-          ? <div className="testo"><p className="infoPanel">Click on Prospecting or Metallurgy to start a task or start fighting from the Combat window.
+          ? <div className="testo"><p className="infoPanel">Click on Prospecting or Metallurgy to start a task or start fighting from the Combat window. You cannot work on tasks while in combat.
           <br/> Mine ores with Prospecting, smelt them with Metallurgy, smith bars into weapons and armor and fight the goblins! 
           <br/> You will unlock more tasks as you level up your skills.  </p></div>
           :  <div>

--- a/drokar-js/src/components/Tasks.js
+++ b/drokar-js/src/components/Tasks.js
@@ -41,7 +41,7 @@ const runTask = (load_task, skill, playerData, setPlayerData) => {
 };
 
 const Tasks = (props) => {
-  const {playerData, setPlayerData, activeTask, setActiveTask, playerLevels} = useContext(PlayerDataContext)
+  const {playerData, setPlayerData, activeTask, setActiveTask, playerLevels, activeCombat} = useContext(PlayerDataContext)
   const irregularTasks = {'Combat': <CombatTasks/>}
   const launchTask = (task, skill, playerData, setPlayerData) => {
     clearInterval(activeTask.taskId)
@@ -49,7 +49,7 @@ const Tasks = (props) => {
 
     var load_task = tasks[skill].find((obj) => obj.name == task.name)
 
-    if (activeTask.name != task.name) {
+    if (activeTask.name != task.name && activeCombat == false) {
       var intervalId = setInterval(runTask, task.duration, load_task, skill, playerData, setPlayerData)
       newTask = {...task,
       taskId: intervalId}


### PR DESCRIPTION
Fixes:
- When starting combat, will end any looping tasks that are running at the time
- While combat is active, tasks cannot be started until combat ends.
- The monster name will properly show on their combat frame